### PR TITLE
Relax lower bound for primitive-unlifted

### DIFF
--- a/primitive-extras.cabal
+++ b/primitive-extras.cabal
@@ -41,7 +41,7 @@ library
     foldl >=1 && <2,
     list-t >=1.0.1 && <1.1,
     primitive >=0.7 && <0.8,
-    primitive-unlifted >=1.0 && <1.1,
+    primitive-unlifted >=0.1 && <1.1,
     profunctors >=5 && <6,
     vector >=0.12 && <0.13
 


### PR DESCRIPTION
`primitive-unlifted-1.0.0.0` does not compile with GHC 9.2 (https://github.com/haskell-primitive/primitive-unlifted/issues/28), while `primitive-unlifted-0.1.3.1` works fine. The [changelog](https://hackage.haskell.org/package/primitive-unlifted-1.0.0.0/changelog) suggests "Stay on the 0.1.x.x series unless you need something from this newer version", and this is indeed the case for `primitive-extras`.